### PR TITLE
Add link to main OpenLiberty guide page

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,9 @@
 :page-related-guides: ['rest-intro', 'cdi-intro', 'microprofile-config']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
+
+The official Open Liberty guide for is available at: https://openliberty.io/guides/microprofile-rest-client.html
+
 = Consuming RESTful services with template interfaces
 
 Learn how to use MicroProfile Rest Client to invoke RESTful microservices over HTTP in a type-safe way.


### PR DESCRIPTION
Since many users are finding this page instead of the main openliberty.io page, we need a link to the main page.