### PR TITLE
Updated guide to MP Rest Client 1.3

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -190,7 +190,7 @@ Now, instantiate the [hotspot=SystemClient file=1]`SystemClient` interface and u
 First, you need to define the base URL of the [hotspot=SystemClient file=1]`SystemClient` instance.
 Configure the default base URL with the MicroProfile Config feature. This feature is enabled for you in both `server.xml` and `pom.xml` files.
 
-[role="code_command hotspot", subs="quotes"]
+[role="code_command hotspot file=0", subs="quotes"]
 ----
 #Create the configuration file.#
 `src/main/webapp/META-INF/microprofile-config.properties`
@@ -201,7 +201,7 @@ microprofile-config.properties
 include::finish/src/main/webapp/META-INF/microprofile-config.properties[]
 ----
 
-The config property [hotspot=baseUri file=0]`systemClient/mp-rest/url` is configured to the default [hotspot=baseUri file=0]`\http://localhost:9080/system` base URL.
+The config property [hotspot=baseUri file=0]`mp-rest/uri` is configured to the default [hotspot=baseUri file=0]`\http://localhost:9080/system` base URL.
 
 This configuration is automatically picked up by the MicroProfile Config API.
 
@@ -218,10 +218,11 @@ By default, interfaces have a `@Dependent` scope unless another scope is defined
 
 The [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation registers the interface as a RESTful client. The runtime creates a CDI managed bean for every interface that is annotated with the `@RegisterRestClient` annotation.
 
-The [hotspot=RegisterRestClient file=1]`configKey` value in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation replaces the fully-qualified classname of the [hotspot=baseUri file=0]`mp-rest/url` property in the MP Config file.
+The [hotspot=RegisterRestClient file=1]`configKey` value in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation replaces the fully-qualified classname of the properties in the [hotspot file=0]`microprofile-config.properties` configuration file.
+For example, the `<fully-qualified classname>/mp-rest/uri` property becomes `systemClient/mp-rest/uri`.
 The benefit of using Config Keys is when multiple client interfaces have the same `configKey` value, the interfaces can be configured with a single MP config property.
 
-The [hotspot=RegisterRestClient file=1]`baseUri` value can also be set in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation. However, this value will be overridden by the [hotspot=baseUri file=0]`mp-rest/url` value defined in the MP Config, as the property defined in the MP Config takes precedence. In a real development and production environment, you can specify a different URI than the production URI just for development and testing purposes. For this guide, try to specify an invalid URI value for the [hotspot=RegisterRestClient file=1]`baseUri` variable and comment out the [hotspot=baseUri file=0]`systemClient/mp-rest/url` property in the [hotspot file=0]`microprofile-config.properties` file. Then, run the `mvn install` command to verify that the `InventoryEndpointTest` fails to connect to the `system` service.
+The [hotspot=RegisterRestClient file=1]`baseUri` value can also be set in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation. However, this value will be overridden by the base URI property defined in the [hotspot file=0]`microprofile-config.properties` configuration file. The property defined in the MicroProfile Config file takes precedence. In a production environment, you can use the `baseUri` variable to specify a different URI than the production URI for development and testing purposes. For this guide, try to specify an invalid URI value for the [hotspot=RegisterRestClient file=1]`baseUri` variable and comment out the [hotspot=baseUri file=0]`mp-rest/uri` property in the [hotspot file=0]`microprofile-config.properties` file. Then, run the `mvn install` command to verify that the `InventoryEndpointTest` fails to connect to the `system` service.
 
 The [hotspot=Dependent file=1]`@Dependent` and [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotations imply that the interface is manageable through CDI. You must have them in order to inject the client.
 

--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ The code for the `system` service in the `src/main/java/io/openliberty/guides/sy
 Create a RESTful client interface for the `system` service. Write a template interface that maps the API of the remote `system` service.
 The template interface describes the remote service that you want to access. The interface defines the resource to access as a method by mapping its annotations, return type, list of arguments, and exception declarations.
 
-[role="code_command hotspot", subs="quotes"]
+[role="code_command hotspot file=2", subs="quotes"]
 ----
 #Create the `SystemClient` class.#
 `src/main/java/io/openliberty/guides/inventory/client/SystemClient.java`
@@ -127,7 +127,7 @@ include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClien
 The MicroProfile Rest Client feature automatically builds and generates a client implementation based on what is defined in the [hotspot=SystemClient file=2]`SystemClient` interface. Thus, you don't waste time on setting up the client and connecting with the remote service.
 
 Notice the [hotspot=SystemClient file=2]`SystemClient` interface inherits the [hotspot=AutoCloseable file=2]`AutoCloseable` interface.
-The client service will automatically close after its invocation, and the underlying resources are cleaned up.
+This allows the user to explicitly close the client instance by invoking the close() method or to implicitly close the client instance using a try-with-resources block. When the client instance is closed, all underlying resources associated with the client instance are cleaned up.
 
 When the [hotspot=getProperties file=2]`getProperties()` method is invoked, the [hotspot=SystemClient file=2]`SystemClient` instance sends a GET request to the `<baseUrl>/properties` endpoint, where `<baseUrl>` is the default base URL of the `system` service. You will see how to configure the base URL in the next section.
 
@@ -201,7 +201,7 @@ microprofile-config.properties
 include::finish/src/main/webapp/META-INF/microprofile-config.properties[]
 ----
 
-The config property [hotspot=baseUri file=0]`mp-rest/uri` is configured to the default [hotspot=baseUri file=0]`\http://localhost:9080/system` base URL.
+The [hotspot=baseUri file=0]`mp-rest/uri` base URL config property is configured to the default [hotspot=baseUri file=0]`\http://localhost:9080/system` URL.
 
 This configuration is automatically picked up by the MicroProfile Config API.
 
@@ -213,18 +213,15 @@ SystemClient.java
 include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[]
 ----
 
-The [hotspot=Dependent file=1]`@Dependent` annotation tells the service that the scope of the interface depends on the class that it is injected into.
-By default, interfaces have a `@Dependent` scope unless another scope is defined on the interface.
-
 The [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation registers the interface as a RESTful client. The runtime creates a CDI managed bean for every interface that is annotated with the `@RegisterRestClient` annotation.
 
 The [hotspot=RegisterRestClient file=1]`configKey` value in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation replaces the fully-qualified classname of the properties in the [hotspot file=0]`microprofile-config.properties` configuration file.
 For example, the `<fully-qualified classname>/mp-rest/uri` property becomes `systemClient/mp-rest/uri`.
 The benefit of using Config Keys is when multiple client interfaces have the same `configKey` value, the interfaces can be configured with a single MP config property.
 
-The [hotspot=RegisterRestClient file=1]`baseUri` value can also be set in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation. However, this value will be overridden by the base URI property defined in the [hotspot file=0]`microprofile-config.properties` configuration file. The property defined in the MicroProfile Config file takes precedence. In a production environment, you can use the `baseUri` variable to specify a different URI than the production URI for development and testing purposes. For this guide, try to specify an invalid URI value for the [hotspot=RegisterRestClient file=1]`baseUri` variable and comment out the [hotspot=baseUri file=0]`mp-rest/uri` property in the [hotspot file=0]`microprofile-config.properties` file. Then, run the `mvn install` command to verify that the `InventoryEndpointTest` fails to connect to the `system` service.
+The [hotspot=RegisterRestClient file=1]`baseUri` value can also be set in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation. However, this value will be overridden by the base URI property defined in the [hotspot file=0]`microprofile-config.properties` configuration file. The property defined in the MicroProfile Config file takes precedence. In a production environment, you can use the `baseUri` variable to specify a different URI for development and testing purposes. For this guide, try to specify an invalid URI value for the [hotspot=RegisterRestClient file=1]`baseUri` variable and comment out the [hotspot=baseUri file=0]`mp-rest/uri` property in the [hotspot file=0]`microprofile-config.properties` file. Then, run the `mvn install` command to verify that the `InventoryEndpointTest` fails to connect to the `system` service.
 
-The [hotspot=Dependent file=1]`@Dependent` and [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotations imply that the interface is manageable through CDI. You must have them in order to inject the client.
+The [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation, which is a bean defining annotation implies that the interface is manageable through CDI. You must have it in order to inject the client.
 
 Inject the [hotspot=SystemClient file=1]`SystemClient` interface into the [hotspot file=2]`InventoryManager` class, which is another CDI managed bean.
 
@@ -241,7 +238,7 @@ include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.j
 
 [hotspot=Inject file=2]`@Inject` and [hotspot=RestClient file=2]`@RestClient` annotations inject an instance of the [hotspot=SystemClient file=2]`SystemClient` called `defaultRestClient` to the [hotspot file=2]`InventoryManager` class.
 
-Since the [hotspot file=2]`InventoryManager` class is [hotspot=ApplicationScoped file=2]`@ApplicationScoped`, and the [hotspot=SystemClient file=1]`SystemClient` CDI bean maintains the same scope through the [hotspot=Dependent file=1]`@Dependent` annotation, the client is initialized once per application.
+Since the [hotspot file=2]`InventoryManager` class is [hotspot=ApplicationScoped file=2]`@ApplicationScoped`, and the [hotspot=SystemClient file=1]`SystemClient` CDI bean maintains the same scope through the default dependent scope, the client is initialized once per application.
 
 If the `hostname` parameter is `localhost`, the service runs the [hotspot=getPropertiesWithDefaultHostName file=2]`getPropertiesWithDefaultHostName()` helper function to fetch system properties.
 The helper function invokes the `system` service by calling the [hotspot=defaultRCGetProperties file=2]`defaultRestClient.getProperties()` method.

--- a/README.adoc
+++ b/README.adoc
@@ -143,7 +143,7 @@ In the [hotspot=SystemClient file=2]`SystemClient` interface, add a response exc
 
 Error handling is an important step to ensure that the application can fail safely. If there is an error response such as `404 NOT FOUND` when invoking the remote service, you need to handle it. First, define an exception, and map the exception with the error response code. Then, register the exception mapper in the client interface.
 
-Look at the client interface again, the [hotspot=RegisterProvider file=0]`@RegisterProvider(UnknownUriExceptionMapper.class)` annotation registers the `UnknownUriExceptionMapper` response exception mapper.
+Look at the client interface again, the [hotspot=RegisterProvider file=0]`@RegisterProvider` annotation registers the `UnknownUriExceptionMapper` response exception mapper.
 An exception mapper maps various response codes from the remote service to throwable exceptions.
 
 SystemClient.java

--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ The application that you will be working with is an `inventory` service, which f
 Whenever a request is made to retrieve the system properties of a particular host, the `inventory` service will create a client to invoke the `system`
 service on that host. The `system` service simulates a remote service in the application.
 
-You will instantiate the client and use it in the `inventory` service. You can choose from two different approaches, Context and Dependency Injection (CDI) with the help of MicroProfile Config or the RestClientBuilder method.
+You will instantiate the client and use it in the `inventory` service. You can choose from two different approaches, https://openliberty.io/docs/ref/general/#contexts_dependency_injection.html[Context and Dependency Injection (CDI)^] with the help of MicroProfile Config or the https://openliberty.io/blog/2018/01/31/mpRestClient.html[RestClientBuilder^] method.
 In this guide, you will explore both methods to handle scenarios for providing a valid base URL.
 
  - When the base URL of the remote service is static and known, define the default base URL in the configuration file. Inject the client with CDI method.

--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,7 @@ include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClien
 The MicroProfile Rest Client feature automatically builds and generates a client implementation based on what is defined in the [hotspot=SystemClient file=2]`SystemClient` interface. Thus, you don't waste time on setting up the client and connecting with the remote service.
 
 Notice the [hotspot=SystemClient file=2]`SystemClient` interface inherits the [hotspot=AutoCloseable file=2]`AutoCloseable` interface.
-This allows the user to explicitly close the client instance by invoking the close() method or to implicitly close the client instance using a try-with-resources block. When the client instance is closed, all underlying resources associated with the client instance are cleaned up.
+This allows the user to explicitly close the client instance by invoking the `close()` method or to implicitly close the client instance using a try-with-resources block. When the client instance is closed, all underlying resources associated with the client instance are cleaned up. Refer to the https://github.com/eclipse/microprofile-rest-client/releases[MicroProfile Rest Client specification^] for more detail.
 
 When the [hotspot=getProperties file=2]`getProperties()` method is invoked, the [hotspot=SystemClient file=2]`SystemClient` instance sends a GET request to the `<baseUrl>/properties` endpoint, where `<baseUrl>` is the default base URL of the `system` service. You will see how to configure the base URL in the next section.
 
@@ -333,7 +333,7 @@ Rerun the Maven build. You see a test failure occur.
 
 You just invoked a remote service by using a template interface with MicroProfile Rest Client in Open Liberty.
 
-Although not covered in this guide, MicroProfile Rest Client provides a uniform way to configure SSL for the client.
+MicroProfile Rest Client also provides a uniform way to configure SSL for the client.
 You can learn more in the https://openliberty.io/blog/2019/06/21/microprofile-rest-client-19006.html#ssl[Hostname verification with SSL on Open Liberty and MicroProfile Rest Client^] blog and the https://github.com/eclipse/microprofile-rest-client/releases[MicroProfile Rest Client specification^].
 
 Feel free to try one of the related guides. They demonstrate more technologies that you can learn and

--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,8 @@
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['rest-intro', 'cdi-intro', 'microprofile-config']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
+:page-seo-title: Consuming REST services with template interfaces
+:page-seo-description: A tutorial and an example on how to consume REST services using MicroProfile Rest Client.
 :source-highlighter: prettify
 = Consuming RESTful services with template interfaces
 
@@ -213,7 +215,7 @@ The [hotspot=14 file=1]`@RegisterRestClient` annotation registers the interface 
 
 The [hotspot=13 file=1]`@Dependent` and [hotspot=14 file=1]`@RegisterRestClient` annotations imply that the interface is manageable through CDI. You must have them in order to inject the client.
 
-Inject the [hotspot=17-22 file=1]`SystemClient` interface into the [hotspot=25-102 file=2]`InventoryManager` class, which is another CDI managed bean. 
+Inject the [hotspot=17-22 file=1]`SystemClient` interface into the [hotspot=25-102 file=2]`InventoryManager` class, which is another CDI managed bean.
 
 [role="code_command hotspot", subs="quotes"]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -119,17 +119,22 @@ The template interface describes the remote service that you want to access. The
 `src/main/java/io/openliberty/guides/inventory/client/SystemClient.java`
 ----
 SystemClient.java
-[source, Java, linenums, role='code_column']
+[source, Java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[]
 ----
 
-The MicroProfile Rest Client feature automatically builds and generates a client implementation based on what is defined in the [hotspot=17-22 file=2]`SystemClient` interface. Thus, you don't waste time on setting up the client and connecting with the remote service.
+The MicroProfile Rest Client feature automatically builds and generates a client implementation based on what is defined in the [hotspot=SystemClient file=2]`SystemClient` interface. Thus, you don't waste time on setting up the client and connecting with the remote service.
 
-When the [hotspot=21 file=2]`getProperties()` method is invoked, the [hotspot=17-22 file=2]`SystemClient` instance sends a GET request to the `<baseUrl>/properties` endpoint, where `<baseUrl>` is the default base URL of the `system` service. You will see how to configure the base URL in the next section.
+Notice the [hotspot=SystemClient file=2]`SystemClient` interface inherits the [hotspot=AutoCloseable file=2]`AutoCloseable` interface.
+The client service will automatically close after its invocation, and the underlying resources are cleaned up.
 
-The [hotspot=15 file=2]`@RegisterProvider` annotation tells the framework to register the provider classes to be used when the framework invokes the interface. You can add as many providers as necessary.
-In the [hotspot=17-22 file=2]`SystemClient` interface, add a response exception mapper as a provider to map the `404` response code with the [hotspot=21 file=2]`UnknownUrlException` exception.
+When the [hotspot=getProperties file=2]`getProperties()` method is invoked, the [hotspot=SystemClient file=2]`SystemClient` instance sends a GET request to the `<baseUrl>/properties` endpoint, where `<baseUrl>` is the default base URL of the `system` service. You will see how to configure the base URL in the next section.
+
+The [hotspot=Produces file=2]`@Produces` annotation specifies the media (MIME) type of the expected response. The default value is `MediaType.APPLICATION_JSON`.
+
+The [hotspot=RegisterProvider file=2]`@RegisterProvider` annotation tells the framework to register the provider classes to be used when the framework invokes the interface. You can add as many providers as necessary.
+In the [hotspot=SystemClient file=2]`SystemClient` interface, add a response exception mapper as a provider to map the `404` response code with the [hotspot=getProperties file=2]`UnknownUriException` exception.
 
 // =================================================================================================
 // Handling exceptions through ResponseExceptionMappers
@@ -138,39 +143,39 @@ In the [hotspot=17-22 file=2]`SystemClient` interface, add a response exception 
 
 Error handling is an important step to ensure that the application can fail safely. If there is an error response such as `404 NOT FOUND` when invoking the remote service, you need to handle it. First, define an exception, and map the exception with the error response code. Then, register the exception mapper in the client interface.
 
-Look at the client interface again, the [hotspot=15 file=0]`@RegisterProvider(UnknownUrlExceptionMapper.class)` annotation registers the `UnknownUrlExceptionMapper` response exception mapper.
+Look at the client interface again, the [hotspot=RegisterProvider file=0]`@RegisterProvider(UnknownUriExceptionMapper.class)` annotation registers the `UnknownUriExceptionMapper` response exception mapper.
 An exception mapper maps various response codes from the remote service to throwable exceptions.
 
 SystemClient.java
-[source, Java, linenums, role='code_column']
+[source, Java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[]
 ----
 
 Implement the actual exception class and the mapper class to see how this mechanism works.
 
-[role="code_command hotspot", subs="quotes"]
+[role="code_command hotspot file=1", subs="quotes"]
 ----
-#Create the `UnknownUrlException` class.#
-`src/main/java/io/openliberty/guides/inventory/client/UnknownUrlException.java`
+#Create the `UnknownUriException` class.#
+`src/main/java/io/openliberty/guides/inventory/client/UnknownUriException.java`
 ----
-UnknownUrlException.java
+UnknownUriException.java
 [source, Java, linenums, role='code_column']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUrlException.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUriException.java[tags=**;!copyright]
 ----
 
-Now, link the [hotspot=3-14 file=1]`UnknownUrlException` class with the corresponding response code through a `ResponseExceptionMapper` mapper class.
+Now, link the [hotspot=3-14 file=1]`UnknownUriException` class with the corresponding response code through a `ResponseExceptionMapper` mapper class.
 
-[role="code_command hotspot", subs="quotes"]
+[role="code_command hotspot file=2", subs="quotes"]
 ----
-#Create the `UnknownUrlExceptionMapper` class.#
-`src/main/java/io/openliberty/guides/inventory/client/UnknownUrlExceptionMapper.java`
+#Create the `UnknownUriExceptionMapper` class.#
+`src/main/java/io/openliberty/guides/inventory/client/UnknownUriExceptionMapper.java`
 ----
-UnknownUrlExceptionMapper.java
+UnknownUriExceptionMapper.java
 [source, Java, linenums, role='code_column']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUrlExceptionMapper.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUriExceptionMapper.java[tags=**;!copyright]
 ----
 
 The [hotspot=15-18 file=2]`handles()` method inspects the HTTP response code to determine whether an exception is thrown for the specific response, and the [hotspot=21-23 file=2]`toThrowable()` method returns the mapped exception.
@@ -180,9 +185,9 @@ The [hotspot=15-18 file=2]`handles()` method inspects the HTTP response code to 
 // =================================================================================================
 == Injecting the client with dependency injection
 
-Now, instantiate the [hotspot=17-22 file=1]`SystemClient` interface and use it in the `inventory` service. If you want to connect only with the default host name, you can easily instantiate the `SystemClient` with CDI annotations. CDI injection simplifies the process of bootstrapping the client.
+Now, instantiate the [hotspot=SystemClient file=1]`SystemClient` interface and use it in the `inventory` service. If you want to connect only with the default host name, you can easily instantiate the `SystemClient` with CDI annotations. CDI injection simplifies the process of bootstrapping the client.
 
-First, you need to define the base URL of the [hotspot=17-22 file=1]`SystemClient` instance.
+First, you need to define the base URL of the [hotspot=SystemClient file=1]`SystemClient` instance.
 Configure the default base URL with the MicroProfile Config feature. This feature is enabled for you in both `server.xml` and `pom.xml` files.
 
 [role="code_command hotspot", subs="quotes"]
@@ -191,49 +196,54 @@ Configure the default base URL with the MicroProfile Config feature. This featur
 `src/main/webapp/META-INF/microprofile-config.properties`
 ----
 microprofile-config.properties
-[source, properties, linenums, role='code_column']
+[source, properties, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/webapp/META-INF/microprofile-config.properties[tags=**;!copyright]
+include::finish/src/main/webapp/META-INF/microprofile-config.properties[]
 ----
 
-The config property [hotspot=1 file=0]`io.openliberty.guides.inventory.client.SystemClient/mp-rest/url` is configured to the default [hotspot=2 file=0]`\http://localhost:9080/system` base URL.
+The config property [hotspot=baseUri file=0]`systemClient/mp-rest/url` is configured to the default [hotspot=baseUri file=0]`\http://localhost:9080/system` base URL.
 
 This configuration is automatically picked up by the MicroProfile Config API.
 
-Look at the annotations in the [hotspot=17-22 file=1]`SystemClient` interface again.
+Look at the annotations in the [hotspot=SystemClient file=1]`SystemClient` interface again.
 
 SystemClient.java
-[source, Java, linenums, role='code_column']
+[source, Java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java[]
 ----
 
-The [hotspot=13 file=1]`@Dependent` annotation tells the service that the scope of the interface depends on the class that it is injected into.
+The [hotspot=Dependent file=1]`@Dependent` annotation tells the service that the scope of the interface depends on the class that it is injected into.
 By default, interfaces have a `@Dependent` scope unless another scope is defined on the interface.
 
-The [hotspot=14 file=1]`@RegisterRestClient` annotation registers the interface as a RESTful client. The runtime creates a CDI managed bean for every interface that is annotated with the `@RegisterRestClient` annotation.
+The [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation registers the interface as a RESTful client. The runtime creates a CDI managed bean for every interface that is annotated with the `@RegisterRestClient` annotation.
 
-The [hotspot=13 file=1]`@Dependent` and [hotspot=14 file=1]`@RegisterRestClient` annotations imply that the interface is manageable through CDI. You must have them in order to inject the client.
+The [hotspot=RegisterRestClient file=1]`configKey` value in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation replaces the fully-qualified classname of the [hotspot=baseUri file=0]`mp-rest/url` property in the MP Config file.
+The benefit of using Config Keys is when multiple client interfaces have the same `configKey` value, the interfaces can be configured with a single MP config property.
 
-Inject the [hotspot=17-22 file=1]`SystemClient` interface into the [hotspot=25-102 file=2]`InventoryManager` class, which is another CDI managed bean.
+The [hotspot=RegisterRestClient file=1]`baseUri` value can also be set in the [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotation. However, this value will be overridden by the [hotspot=baseUri file=0]`mp-rest/url` value defined in the MP Config, as the property defined in the MP Config takes precedence. In a real development and production environment, you can specify a different URI than the production URI just for development and testing purposes. For this guide, try to specify an invalid URI value for the [hotspot=RegisterRestClient file=1]`baseUri` variable and comment out the [hotspot=baseUri file=0]`systemClient/mp-rest/url` property in the [hotspot file=0]`microprofile-config.properties` file. Then, run the `mvn install` command to verify that the `InventoryEndpointTest` fails to connect to the `system` service.
 
-[role="code_command hotspot", subs="quotes"]
+The [hotspot=Dependent file=1]`@Dependent` and [hotspot=RegisterRestClient file=1]`@RegisterRestClient` annotations imply that the interface is manageable through CDI. You must have them in order to inject the client.
+
+Inject the [hotspot=SystemClient file=1]`SystemClient` interface into the [hotspot file=2]`InventoryManager` class, which is another CDI managed bean.
+
+[role="code_command hotspot file=2", subs="quotes"]
 ----
 #Create the `InventoryManager` class.#
 `src/main/java/io/openliberty/guides/inventory/InventoryManager.java`
 ----
 InventoryManager.java
-[source, Java, linenums, role='code_column']
+[source, Java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[]
 ----
 
-[hotspot=30 file=2]`@Inject` and [hotspot=31 file=2]`@RestClient` annotations inject an instance of the [hotspot=32 file=2]`SystemClient` called `defaultRestClient` to the [hotspot=25-99 file=2]`InventoryManager` class.
+[hotspot=Inject file=2]`@Inject` and [hotspot=RestClient file=2]`@RestClient` annotations inject an instance of the [hotspot=SystemClient file=2]`SystemClient` called `defaultRestClient` to the [hotspot file=2]`InventoryManager` class.
 
-Since the [hotspot=25-102 file=2]`InventoryManager` class is [hotspot=24 file=2]`@ApplicationScoped`, and the [hotspot=17-22 file=1]`SystemClient` CDI bean maintains the same scope through the [hotspot=13 file=1]`@Dependent` annotation, the client is initialized once per application.
+Since the [hotspot file=2]`InventoryManager` class is [hotspot=ApplicationScoped file=2]`@ApplicationScoped`, and the [hotspot=SystemClient file=1]`SystemClient` CDI bean maintains the same scope through the [hotspot=Dependent file=1]`@Dependent` annotation, the client is initialized once per application.
 
-If the `hostname` parameter is `localhost`, the service runs the [hotspot=59-68 file=2]`getPropertiesWithDefaultHostName()` helper function to fetch system properties.
-The helper function invokes the `system` service by calling the [hotspot=61 file=2]`defaultRestClient.getProperties()` method.
+If the `hostname` parameter is `localhost`, the service runs the [hotspot=getPropertiesWithDefaultHostName file=2]`getPropertiesWithDefaultHostName()` helper function to fetch system properties.
+The helper function invokes the `system` service by calling the [hotspot=defaultRCGetProperties file=2]`defaultRestClient.getProperties()` method.
 
 // =================================================================================================
 // Building the client with RestClientBuilder
@@ -243,18 +253,18 @@ The helper function invokes the `system` service by calling the [hotspot=61 file
 The `inventory` service might also connect with a host other than the default `localhost` host. Then, you cannot configure a base URL that is not yet known.
 Therefore, set the host name as a variable and build the client by using the `RestClientBuilder` method. You can customize the base URL from the host name attribute.
 
-Look at the [hotspot=70-88]`getPropertiesWithGivenHostName()` method in the `src/main/java/io/openliberty/guides/inventory/InventoryManager.java` file.
+Look at the [hotspot=getPropertiesWithGivenHostName]`getPropertiesWithGivenHostName()` method in the `src/main/java/io/openliberty/guides/inventory/InventoryManager.java` file.
 
 InventoryManager.java
-[source, Java, linenums, role='code_column']
+[source, Java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[tags=**;!copyright]
+include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[]
 ----
 
 The host name is provided as a parameter. This method first assembles the base URL that consists of the new host name.
-Then, the method instantiates a [hotspot=75-78]`RestClientBuilder` builder with the new URL, registers the response exception mapper, and builds the `SystemClient` instance.
+Then, the method instantiates a [hotspot=customRestClientBuilder]`RestClientBuilder` builder with the new URL, registers the response exception mapper, and builds the `SystemClient` instance.
 
-Similarly, call the [hotspot=79]`customRestClient.getProperties()` method to invoke the `system` service.
+Similarly, call the [hotspot=customRCGetProperties]`customRestClient.getProperties()` method to invoke the `system` service.
 
 // =================================================================================================
 // Building and running the application
@@ -318,12 +328,15 @@ Results :
 Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-To see whether the tests detect a failure, change the base URL in the configuration file so that when the `inventory` service tries to access the invalid URL, an UnknownUrlException is thrown.
+To see whether the tests detect a failure, change the base URL in the configuration file so that when the `inventory` service tries to access the invalid URL, an UnknownUriException is thrown.
 Rerun the Maven build. You see a test failure occur.
 
 == Great work! You're done!
 
 You just invoked a remote service by using a template interface with MicroProfile Rest Client in Open Liberty.
+
+Although not covered in this guide, MicroProfile Rest Client provides a uniform way to configure SSL for the client.
+You can learn more in the https://openliberty.io/blog/2019/06/21/microprofile-rest-client-19006.html#ssl[Hostname verification with SSL on Open Liberty and MicroProfile Rest Client^] blog and the https://github.com/eclipse/microprofile-rest-client/releases[MicroProfile Rest Client specification^].
 
 Feel free to try one of the related guides. They demonstrate more technologies that you can learn and
 expand on what you built here.

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -13,26 +13,27 @@
 // tag::manager[]
 package io.openliberty.guides.inventory;
 
-import java.net.URL;
 import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.net.MalformedURLException;
-import javax.ws.rs.ProcessingException;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import javax.inject.Inject;
+
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.ProcessingException;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.openliberty.guides.inventory.client.SystemClient;
+import io.openliberty.guides.inventory.client.UnknownUrlExceptionMapper;
 import io.openliberty.guides.inventory.model.InventoryList;
 import io.openliberty.guides.inventory.model.SystemData;
-import io.openliberty.guides.inventory.client.SystemClient;
-import io.openliberty.guides.inventory.client.UnknownUrlException;
-import io.openliberty.guides.inventory.client.UnknownUrlExceptionMapper;
 
 @ApplicationScoped
 public class InventoryManager {
@@ -72,8 +73,8 @@ public class InventoryManager {
   private Properties getPropertiesWithDefaultHostName() {
     try {
       return defaultRestClient.getProperties();
-    } catch (UnknownUrlException e) {
-      System.err.println("The given URL is unreachable.");
+    } catch (URISyntaxException e) {
+        System.err.println("The given URI is not formatted correctly.");
     } catch (ProcessingException ex) {
       handleProcessingException(ex);
     }
@@ -82,21 +83,19 @@ public class InventoryManager {
 
   // tag::builder[]
   private Properties getPropertiesWithGivenHostName(String hostname) {
-    String customURLString = "http://" + hostname + ":" + DEFAULT_PORT + "/system";
-    URL customURL = null;
+    String customURIString = "http://" + hostname + ":" + DEFAULT_PORT + "/system";
+    URI customURI = null;
     try {
-      customURL = new URL(customURLString);
+      customURI = new URI(customURIString);
       SystemClient customRestClient = RestClientBuilder.newBuilder()
-                                         .baseUrl(customURL)
+                                         .baseUri(customURI)
                                          .register(UnknownUrlExceptionMapper.class)
                                          .build(SystemClient.class);
       return customRestClient.getProperties();
     } catch (ProcessingException ex) {
       handleProcessingException(ex);
-    } catch (UnknownUrlException e) {
-      System.err.println("The given URL is unreachable.");
-    } catch (MalformedURLException e) {
-      System.err.println("The given URL is not formatted correctly.");
+    } catch (URISyntaxException e) {
+      System.err.println("The given URI is not formatted correctly.");
     }
     return null;
   }

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -112,7 +112,7 @@ public class InventoryManager {
     } catch (ProcessingException ex) {
       handleProcessingException(ex);
     } catch (UnknownUriException e) {
-      System.err.println("The given URI is not formatted correctly.");
+      System.err.println("The given URI is unreachable.");
     } catch (URISyntaxException e) {
         System.err.println("The given URI syntax is not correct.");
     }

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -98,13 +98,12 @@ public class InventoryManager {
     String customURIString = "http://" + hostname + ":" + DEFAULT_PORT + "/system";
     URI customURI = null;
     try {
-      //customURI = new URI(customURIString);
       customURI = URI.create(customURIString);
       // tag::customRestClientBuilder[]
       SystemClient customRestClient = RestClientBuilder.newBuilder()
-                                                       .baseUri(customURI)
-                                                       .register(UnknownUriExceptionMapper.class)
-                                                       .build(SystemClient.class);
+                                          .baseUri(customURI)
+                                          .register(UnknownUriExceptionMapper.class)
+                                          .build(SystemClient.class);
       // end::customRestClientBuilder[]
       // tag::customRCGetProperties[]
       return customRestClient.getProperties();

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -86,7 +86,7 @@ public class InventoryManager {
       return defaultRestClient.getProperties();
       // end::defaultRCGetProperties[]
     } catch (UnknownUriException e) {
-        System.err.println("The given URI is not formatted correctly.");
+      System.err.println("The given URI is not formatted correctly.");
     } catch (ProcessingException ex) {
       handleProcessingException(ex);
     }
@@ -101,10 +101,8 @@ public class InventoryManager {
     try {
       customURI = new URI(customURIString);
       // tag::customRestClientBuilder[]
-      SystemClient customRestClient = RestClientBuilder.newBuilder()
-                                         .baseUri(customURI)
-                                         .register(UnknownUriExceptionMapper.class)
-                                         .build(SystemClient.class);
+      SystemClient customRestClient = RestClientBuilder.newBuilder().baseUri(customURI)
+          .register(UnknownUriExceptionMapper.class).build(SystemClient.class);
       // end::customRestClientBuilder[]
       // tag::customRCGetProperties[]
       return customRestClient.getProperties();
@@ -114,7 +112,7 @@ public class InventoryManager {
     } catch (UnknownUriException e) {
       System.err.println("The given URI is unreachable.");
     } catch (URISyntaxException e) {
-        System.err.println("The given URI syntax is not correct.");
+      System.err.println("The given URI syntax is not correct.");
     }
     return null;
   }
@@ -122,8 +120,8 @@ public class InventoryManager {
 
   private void handleProcessingException(ProcessingException ex) {
     Throwable rootEx = ExceptionUtils.getRootCause(ex);
-    if (rootEx != null && (rootEx instanceof UnknownHostException ||
-        rootEx instanceof ConnectException)) {
+    if (rootEx != null && (rootEx instanceof UnknownHostException
+        || rootEx instanceof ConnectException)) {
       System.err.println("The specified host is unknown.");
     } else {
       throw ex;

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -15,7 +15,6 @@ package io.openliberty.guides.inventory;
 
 import java.net.ConnectException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -99,10 +98,13 @@ public class InventoryManager {
     String customURIString = "http://" + hostname + ":" + DEFAULT_PORT + "/system";
     URI customURI = null;
     try {
-      customURI = new URI(customURIString);
+      //customURI = new URI(customURIString);
+      customURI = URI.create(customURIString);
       // tag::customRestClientBuilder[]
-      SystemClient customRestClient = RestClientBuilder.newBuilder().baseUri(customURI)
-          .register(UnknownUriExceptionMapper.class).build(SystemClient.class);
+      SystemClient customRestClient = RestClientBuilder.newBuilder()
+                                                       .baseUri(customURI)
+                                                       .register(UnknownUriExceptionMapper.class)
+                                                       .build(SystemClient.class);
       // end::customRestClientBuilder[]
       // tag::customRCGetProperties[]
       return customRestClient.getProperties();
@@ -111,8 +113,6 @@ public class InventoryManager {
       handleProcessingException(ex);
     } catch (UnknownUriException e) {
       System.err.println("The given URI is unreachable.");
-    } catch (URISyntaxException e) {
-      System.err.println("The given URI syntax is not correct.");
     }
     return null;
   }

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -27,15 +27,29 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import java.lang.AutoCloseable;
 
 // tag::annotations[]
+// tag::Dependent[]
 @Dependent
+// end::Dependent[]
+// tag::RegisterRestClient[]
 @RegisterRestClient(configKey="systemClient", baseUri="http://localhost:9080/system")
-@RegisterProvider(UnknownUrlExceptionMapper.class)
+// end::RegisterRestClient[]
+// tag::RegisterProvider[]
+@RegisterProvider(UnknownUriExceptionMapper.class)
+// end::RegisterProvider[]
 @Path("/properties")
+// tag::SystemClient[]
+// tag::AutoCloseable[]
 public interface SystemClient extends AutoCloseable {
-  // end::annotations[]
+// end::AutoCloseable[]
+// end::annotations[]
 
   @GET
+  // tag::Produces[]
   @Produces(MediaType.APPLICATION_JSON)
-  public Properties getProperties() throws URISyntaxException, ProcessingException;
+  // end::Produces[]
+  // tag::getProperties[]
+  public Properties getProperties() throws UnknownUriException, ProcessingException;
+  // end::getProperties[]
 }
+// end::SystemClient[]
 // end::client[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 // tag::client[]
 package io.openliberty.guides.inventory.client;
 
+import java.net.URISyntaxException;
 import java.util.Properties;
 import javax.enterprise.context.Dependent;
 import javax.ws.rs.ProcessingException;
@@ -20,19 +21,21 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import java.lang.AutoCloseable;
 
 // tag::annotations[]
 @Dependent
-@RegisterRestClient
+@RegisterRestClient(configKey="systemClient", baseUri="http://localhost:9080/system")
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")
-public interface SystemClient {
+public interface SystemClient extends AutoCloseable {
   // end::annotations[]
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public Properties getProperties() throws UnknownUrlException, ProcessingException;
+  public Properties getProperties() throws URISyntaxException, ProcessingException;
 }
 // end::client[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -13,7 +13,6 @@
 // tag::client[]
 package io.openliberty.guides.inventory.client;
 
-import java.net.URISyntaxException;
 import java.util.Properties;
 import javax.enterprise.context.Dependent;
 import javax.ws.rs.ProcessingException;
@@ -24,6 +23,8 @@ import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.openliberty.guides.inventory.client.UnknownUriException;
+import io.openliberty.guides.inventory.client.UnknownUriExceptionMapper;
 import java.lang.AutoCloseable;
 
 // tag::annotations[]
@@ -31,7 +32,7 @@ import java.lang.AutoCloseable;
 @Dependent
 // end::Dependent[]
 // tag::RegisterRestClient[]
-@RegisterRestClient(configKey="systemClient", baseUri="http://localhost:9080/system")
+@RegisterRestClient(configKey = "systemClient", baseUri = "http://localhost:9080/system")
 // end::RegisterRestClient[]
 // tag::RegisterProvider[]
 @RegisterProvider(UnknownUriExceptionMapper.class)

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -14,23 +14,16 @@
 package io.openliberty.guides.inventory.client;
 
 import java.util.Properties;
-import javax.enterprise.context.Dependent;
-import javax.ws.rs.ProcessingException;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.openliberty.guides.inventory.client.UnknownUriException;
-import io.openliberty.guides.inventory.client.UnknownUriExceptionMapper;
-import java.lang.AutoCloseable;
 
-// tag::annotations[]
-// tag::Dependent[]
-@Dependent
-// end::Dependent[]
 // tag::RegisterRestClient[]
 @RegisterRestClient(configKey = "systemClient", baseUri = "http://localhost:9080/system")
 // end::RegisterRestClient[]
@@ -42,7 +35,6 @@ import java.lang.AutoCloseable;
 // tag::AutoCloseable[]
 public interface SystemClient extends AutoCloseable {
 // end::AutoCloseable[]
-// end::annotations[]
 
   @GET
   // tag::Produces[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUriException.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUriException.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,15 +13,15 @@
 // tag::exception[]
 package io.openliberty.guides.inventory.client;
 
-public class UnknownUrlException extends Exception {
+public class UnknownUriException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
-  public UnknownUrlException() {
+  public UnknownUriException() {
     super();
   }
 
-  public UnknownUrlException(String message) {
+  public UnknownUriException(String message) {
     super(message);
   }
 }

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUriExceptionMapper.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/UnknownUriExceptionMapper.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,9 +20,9 @@ import javax.ws.rs.ext.Provider;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 
 @Provider
-public class UnknownUrlExceptionMapper
-    implements ResponseExceptionMapper<UnknownUrlException> {
-  Logger LOG = Logger.getLogger(UnknownUrlExceptionMapper.class.getName());
+public class UnknownUriExceptionMapper
+    implements ResponseExceptionMapper<UnknownUriException> {
+  Logger LOG = Logger.getLogger(UnknownUriExceptionMapper.class.getName());
 
   @Override
   public boolean handles(int status, MultivaluedMap<String, Object> headers) {
@@ -31,8 +31,8 @@ public class UnknownUrlExceptionMapper
   }
 
   @Override
-  public UnknownUrlException toThrowable(Response response) {
-    return new UnknownUrlException();
+  public UnknownUriException toThrowable(Response response) {
+    return new UnknownUriException();
   }
 }
 // end::mapper[]

--- a/finish/src/main/webapp/META-INF/microprofile-config.properties
+++ b/finish/src/main/webapp/META-INF/microprofile-config.properties
@@ -1,3 +1,5 @@
 # tag::config[]
-systemClient/mp-rest/url=http://localhost:9080/system
+# tag::baseUri[]
+systemClient/mp-rest/uri=http://localhost:9080/system
+# end::baseUri[]
 # end::config[]

--- a/finish/src/main/webapp/META-INF/microprofile-config.properties
+++ b/finish/src/main/webapp/META-INF/microprofile-config.properties
@@ -1,4 +1,3 @@
 # tag::config[]
-io.openliberty.guides.inventory.client.SystemClient/mp-rest/\
-url=http://localhost:9080/system
+systemClient/mp-rest/url=http://localhost:9080/system
 # end::config[]


### PR DESCRIPTION
As suggested in https://github.com/OpenLiberty/guides-common/issues/240, the following new features are being updated in the rest client guide: 
- [x] add the URI directly in the `@RegisterRestClient` annotation on the rest client interface
- [x] portable SSL APIs - this might be something to mention, but not necessary change the samples?
- [x] `configKeys` - this is a nifty feature to configure multiple rest client interfaces with a single config line
- [x] rest client interfaces can extend (or be casted to) `Closeable`/`AutoCloseable` allowing the user to control when the client is closed (and resources cleaned up)
- [x] default MIME types when not specified by the app is now application/json - if any of the samples do not specify `@Produces(...)` and `@Consumes(...)`, then should be updated to do so.

The following point is not covered: 
- use the new `@ClientHeaderParam` annotation to send hardcoded or computed HTTP headers