### PR TITLE
Dependency update

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -15,12 +15,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
-        <!-- Plugin versions -->
-        <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
-        <version.maven-war-plugin>3.2.3</version.maven-war-plugin>
-        <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.liberty-maven-plugin>3.2</version.liberty-maven-plugin>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
@@ -30,7 +24,7 @@
         <!-- Provided dependencies -->
         <dependency>
             <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
@@ -82,25 +76,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${version.maven-war-plugin}</version>
+                <version>3.2.3</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.maven-surefire-plugin}</version>
+                <version>2.22.2</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>${version.liberty-maven-plugin}</version>
+                <version>3.2</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.maven-failsafe-plugin}</version>
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <http.port>${liberty.var.default.http.port}</http.port>

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -17,21 +17,6 @@
 <body>
     <h1>Welcome to your Open Liberty application</h1>
     <p>Open Liberty is a lightweight open framework for building fast and efficient cloud-native Java microservices. Find out more at <a href="http://openliberty.io/" target="_blank" rel="noopener noreferrer">openliberty.io</a>.</p>
-<!--
-  Copyright (c) 2016, 2020 IBM Corp.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
 <div>
     <h2>Eclipse MicroProfile</h2>
     <p>
@@ -53,7 +38,6 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-1.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 1.1</a></li>
         </ul>
     </p>
-</div>
 </div>
 </body>
 </html>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -15,12 +15,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
-        <!-- Plugin versions -->
-        <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
-        <version.maven-war-plugin>3.2.3</version.maven-war-plugin>
-        <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.liberty-maven-plugin>3.2</version.liberty-maven-plugin>
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
@@ -30,7 +24,7 @@
         <!-- Provided dependencies -->
         <dependency>
             <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
@@ -82,25 +76,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${version.maven-war-plugin}</version>
+                <version>3.2.3</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.maven-surefire-plugin}</version>
+                <version>2.22.2</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>${version.liberty-maven-plugin}</version>
+                <version>3.2</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.maven-failsafe-plugin}</version>
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <http.port>${liberty.var.default.http.port}</http.port>

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -17,21 +17,6 @@
 <body>
     <h1>Welcome to your Open Liberty application</h1>
     <p>Open Liberty is a lightweight open framework for building fast and efficient cloud-native Java microservices. Find out more at <a href="http://openliberty.io/" target="_blank" rel="noopener noreferrer">openliberty.io</a>.</p>
-<!--
-  Copyright (c) 2016, 2020 IBM Corp.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
 <div>
     <h2>Eclipse MicroProfile</h2>
     <p>
@@ -53,7 +38,6 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-1.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 1.1</a></li>
         </ul>
     </p>
-</div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
- Issue: OpenLiberty/guides-common#436
    - jakarta web -> jakarta api
    - specify versions at the plugin directly
    - remove `<failOnMissingWebXml>false</failOnMissingWebXml>`
- fix index.html: OpenLiberty/guides-common#431