### PR TITLE
Updates the trigger action for the renamed quick-labs repo on QA branch

### DIFF
--- a/.github/workflows/triggerConversion.yml
+++ b/.github/workflows/triggerConversion.yml
@@ -25,7 +25,7 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: GuideConverter
-        repo: OpenLiberty/quick-labs
+        repo: OpenLiberty/cloud-hosted-guides
         token: ${{ secrets.GUIDECONVERSIONTOOL_PASSWORD }}
         inputs: '{ "branch": "${{ github.ref }}", "guide_name": "${{ github.event.repository.name }}" }'
         ref: "refs/heads/master"


### PR DESCRIPTION
The quick-labs repository is being renamed to cloud-hosted-guides and requires changes to the trigger actions as a result.